### PR TITLE
분리된 캐싱작업을 동일한 job 에서 실행되도록 수정

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -7,8 +7,8 @@ on:
     workflow_dispatch:
 
 jobs:
-    cache:
-        name: Cache Node Modules
+    deploy:
+        name: Deploy
         runs-on: self-hosted
         steps:
             - name: Checkout Code
@@ -26,20 +26,6 @@ jobs:
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
                   restore-keys: |
                       ${{ runner.os }}-yarn-
-
-    deploy:
-        name: Deploy
-        runs-on: self-hosted
-        needs: cache
-
-        steps:
-            - name: Checkout Code
-              uses: actions/checkout@v4
-
-            - name: Set up Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 22
 
             - name: Install Yarn PackageManager
               run: npm install -g yarn


### PR DESCRIPTION
- `self-hosted` 러너의 경우 각 job은 새로운 워크스페이스(새로운 작업 디렉토리)에서 실행됨
- 분리되어있던 `Cache Node Modules` job 과 `Deploy` job 을 통합