### PR TITLE
fix: 게시글 목록 페이지 카테고리 overflow scroll 처리

### DIFF
--- a/src/entities/filter/ui/CategoryMenu.tsx
+++ b/src/entities/filter/ui/CategoryMenu.tsx
@@ -38,7 +38,7 @@ export const CategoryMenu = () => {
                 <SlidersHorizontal size={14} />
                 Categories
             </h2>
-            <nav className="flex flex-row flex-nowrap gap-1 py-2 lg:flex-col">
+            <nav className="flex flex-row flex-nowrap gap-1 overflow-x-scroll py-2 lg:flex-col">
                 {siteConfiguration.category.map((category, index) => {
                     return (
                         <Category


### PR DESCRIPTION
- 모바일 디바이스에서 게시글 목록 페이지 카테고리가 overflow 되는 현상 수정
<img src="https://github.com/user-attachments/assets/55ede5e8-56dd-4967-b106-c5c0bdc914da" width="300px"/>
